### PR TITLE
changes log settings and format and namespaces log messages differently

### DIFF
--- a/companionpages/api/views.py
+++ b/companionpages/api/views.py
@@ -15,7 +15,7 @@ from rest_framework import status
 from lib.storage import upload_path
 from lib import crossref
 
-logger = logging.getLogger(__name__)
+logger = logging.getLogger('researchcompendia.api')
 
 
 @api_view(['GET'])

--- a/companionpages/companionpages/settings.py
+++ b/companionpages/companionpages/settings.py
@@ -286,7 +286,8 @@ LOGGING = {
     'disable_existing_loggers': False,
     'formatters': {
         'verbose': {
-            'format': '%(levelname)s %(asctime)s %(module)s %(process)d %(thread)d %(message)s'
+            'format': '%(asctime)s|%(levelname)s|%(name)s|%(module)s|%(funcName)s|%(process)d|%(thread)d|%(message)s',
+            'datefmt': '%Y%m%d-%H:%M:%S',
         },
         'simple': {
             'format': '%(levelname)s %(message)s'
@@ -314,17 +315,14 @@ LOGGING = {
         'django.request': {
             'handlers': ['mail_admins', 'console'],
             'level': 'INFO',
-            'propagate': True,
         },
         'django.db.backends': {
             'handlers': ['console'],
             'level': 'INFO',
-            'propagate': True,
         },
-        'compendia': {
-            'handlers': ['console'],
+        'researchcompendia': {
+            'handlers': ['mail_admins', 'console'],
             'level': 'DEBUG',
-            'propagate': True,
         },
     },
 }

--- a/companionpages/compendia/views.py
+++ b/companionpages/compendia/views.py
@@ -7,7 +7,7 @@ from braces.views import FormMessagesMixin, LoginRequiredMixin
 from .models import Article
 from .forms import ArticleForm, ArticleUpdateForm
 
-logger = logging.getLogger(__name__)
+logger = logging.getLogger('researchcompendia.compendia')
 
 
 class ArticleListView(generic.ListView):
@@ -48,7 +48,8 @@ class ArticleCreateView(LoginRequiredMixin, FormMessagesMixin, generic.edit.Crea
         return super(ArticleCreateView, self).form_valid(form)
 
     def get_form_invalid_message(self):
-        logger.error('An attempt to create an article has failed. PATH: %s GET: %s POST: %s', self.request.path, self.request.GET, self.request.POST)
+        logger.error('An attempt to create an article has failed. USER: %s PATH: %s GET: %s POST: %s',
+                self.request.user, self.request.path, self.request.GET, self.request.POST)
         return 'The article was not created, and the site administrators have been notified.'
 
     def get_form_valid_message(self):

--- a/companionpages/lib/crossref.py
+++ b/companionpages/lib/crossref.py
@@ -1,10 +1,11 @@
 import logging
 import re
+from urllib import quote
 
 from bs4 import BeautifulSoup
 import requests
 
-logger = logging.getLogger(__name__)
+logger = logging.getLogger('researchcompendia.lib')
 
 """
 This is an unsophisticated library to parse responses from the crossref query servlet.
@@ -93,7 +94,7 @@ def query(pid, doi_param, timeout=0.60):
 
 
 def parse_crossref_output(xml):
-    logger.debug('crossref output: %s', xml)
+    logger.debug('crossref output: %s', quote(xml))
 
     # I'm using 'xml' instead of 'lxml' because 'lxml' ignores CDATA,
     # but 'xml' turns CDATA in to text elements

--- a/companionpages/lib/scrapers.py
+++ b/companionpages/lib/scrapers.py
@@ -3,7 +3,7 @@ import logging
 from bs4 import BeautifulSoup
 import requests
 
-logger = logging.getLogger(__name__)
+logger = logging.getLogger('researchcompendia.lib')
 
 
 def scrape_abstract(article_url, timeout=3):


### PR DESCRIPTION
Changed verbose log format to be pipe-delimited and with a less human friendly timestamp. up with machines.
**name** isn't that great for loggers, started using 'researchcompendia.foo'
