### PR TITLE
ASA browse experiment

### DIFF
--- a/companionpages/compendia/admin.py
+++ b/companionpages/compendia/admin.py
@@ -54,5 +54,5 @@ admin.site.register(Contributor, ContributorAdmin)
 admin.site.register(TaggedArticle, TaggedArticleAdmin)
 admin.site.register(Verification, VerificationAdmin)
 admin.site.register(TableOfContentsOption,
-    list_display = ['compendium_type'],
+    list_display=['compendium_type'],
 )

--- a/companionpages/compendia/admin.py
+++ b/companionpages/compendia/admin.py
@@ -1,5 +1,5 @@
 from django.contrib import admin
-from .models import Contributor, Article, Verification, TaggedArticle
+from .models import Contributor, Article, Verification, TaggedArticle, TableOfContentsOption
 from . import choices
 
 
@@ -53,3 +53,6 @@ admin.site.register(Article, ArticleAdmin)
 admin.site.register(Contributor, ContributorAdmin)
 admin.site.register(TaggedArticle, TaggedArticleAdmin)
 admin.site.register(Verification, VerificationAdmin)
+admin.site.register(TableOfContentsOption,
+    list_display = ['compendium_type'],
+)

--- a/companionpages/compendia/choices.py
+++ b/companionpages/compendia/choices.py
@@ -184,10 +184,10 @@ ENTRY_TYPES = Choices(
     ('misc_negative_results', _(u'Negative Results')),
     ('misc_public_tool', _(u'Public Tool')),
     ('misc_course', _(u'Course')),
-    ('misc_lecture_notes', _(u'Lecture Notes')),
+    ('misc_lecture_notes', _(u'Lecture Note')),
     ('misc_dataset', _(u'Data')),
     ('misc_software', _(u'Software')),
-    ('misc_problem_sets', _(u'Problem Sets')),
+    ('misc_problem_sets', _(u'Problem Set')),
 )
 ENTRY_TYPE_LOOKUP = dict(ENTRY_TYPES)
 

--- a/companionpages/compendia/migrations/0015_auto__add_tableofcontentsoption.py
+++ b/companionpages/compendia/migrations/0015_auto__add_tableofcontentsoption.py
@@ -1,0 +1,164 @@
+# -*- coding: utf-8 -*-
+from south.utils import datetime_utils as datetime
+from south.db import db
+from south.v2 import SchemaMigration
+from django.db import models
+
+
+class Migration(SchemaMigration):
+
+    def forwards(self, orm):
+        # Adding model 'TableOfContentsOption'
+        db.create_table(u'compendia_tableofcontentsoption', (
+            (u'id', self.gf('django.db.models.fields.AutoField')(primary_key=True)),
+            ('compendium_type', self.gf('django.db.models.fields.CharField')(default='misc', unique=True, max_length=100)),
+            ('description', self.gf('markitup.fields.MarkupField')(max_length=500, no_rendered_field=True, blank=True)),
+            ('_description_rendered', self.gf('django.db.models.fields.TextField')(blank=True)),
+        ))
+        db.send_create_signal(u'compendia', ['TableOfContentsOption'])
+
+
+    def backwards(self, orm):
+        # Deleting model 'TableOfContentsOption'
+        db.delete_table(u'compendia_tableofcontentsoption')
+
+
+    models = {
+        u'auth.group': {
+            'Meta': {'object_name': 'Group'},
+            u'id': ('django.db.models.fields.AutoField', [], {'primary_key': 'True'}),
+            'name': ('django.db.models.fields.CharField', [], {'unique': 'True', 'max_length': '80'}),
+            'permissions': ('django.db.models.fields.related.ManyToManyField', [], {'to': u"orm['auth.Permission']", 'symmetrical': 'False', 'blank': 'True'})
+        },
+        u'auth.permission': {
+            'Meta': {'ordering': "(u'content_type__app_label', u'content_type__model', u'codename')", 'unique_together': "((u'content_type', u'codename'),)", 'object_name': 'Permission'},
+            'codename': ('django.db.models.fields.CharField', [], {'max_length': '100'}),
+            'content_type': ('django.db.models.fields.related.ForeignKey', [], {'to': u"orm['contenttypes.ContentType']"}),
+            u'id': ('django.db.models.fields.AutoField', [], {'primary_key': 'True'}),
+            'name': ('django.db.models.fields.CharField', [], {'max_length': '50'})
+        },
+        u'compendia.article': {
+            'Meta': {'ordering': "['title']", 'object_name': 'Article'},
+            '_admin_notes_rendered': ('django.db.models.fields.TextField', [], {'blank': 'True'}),
+            '_code_data_abstract_rendered': ('django.db.models.fields.TextField', [], {'blank': 'True'}),
+            '_manual_citation_rendered': ('django.db.models.fields.TextField', [], {'blank': 'True'}),
+            '_paper_abstract_rendered': ('django.db.models.fields.TextField', [], {'blank': 'True'}),
+            'admin_notes': ('markitup.fields.MarkupField', [], {'max_length': '5000', 'no_rendered_field': 'True', 'blank': 'True'}),
+            'article_file': ('django.db.models.fields.files.FileField', [], {'max_length': '100', 'blank': 'True'}),
+            'article_url': ('django.db.models.fields.URLField', [], {'max_length': '2000', 'blank': 'True'}),
+            'authors_text': ('django.db.models.fields.TextField', [], {'max_length': '500'}),
+            'authorship': ('jsonfield.fields.JSONField', [], {'default': "'{}'"}),
+            'bibjson': ('jsonfield.fields.JSONField', [], {'default': "'{}'"}),
+            'book_file': ('django.db.models.fields.files.FileField', [], {'max_length': '100', 'null': 'True', 'blank': 'True'}),
+            'code_archive_file': ('django.db.models.fields.files.FileField', [], {'max_length': '100', 'blank': 'True'}),
+            'code_data_abstract': ('markitup.fields.MarkupField', [], {'max_length': '5000', 'no_rendered_field': 'True', 'blank': 'True'}),
+            'code_doi': ('django.db.models.fields.CharField', [], {'max_length': '2000', 'blank': 'True'}),
+            'code_license': ('django.db.models.fields.CharField', [], {'max_length': '100', 'blank': 'True'}),
+            'compendium_type': ('django.db.models.fields.CharField', [], {'max_length': '100', 'blank': 'True'}),
+            'content_license': ('django.db.models.fields.CharField', [], {'max_length': '100', 'blank': 'True'}),
+            'contributors': ('django.db.models.fields.related.ManyToManyField', [], {'related_name': "'contributors'", 'to': u"orm['users.User']", 'through': u"orm['compendia.Contributor']", 'blank': 'True', 'symmetrical': 'False', 'null': 'True'}),
+            'created': ('model_utils.fields.AutoCreatedField', [], {'default': 'datetime.datetime.now'}),
+            'data_archive_file': ('django.db.models.fields.files.FileField', [], {'max_length': '100', 'blank': 'True'}),
+            'data_doi': ('django.db.models.fields.CharField', [], {'max_length': '2000', 'blank': 'True'}),
+            'doi': ('django.db.models.fields.CharField', [], {'max_length': '2000', 'blank': 'True'}),
+            'homework_archive_file': ('django.db.models.fields.files.FileField', [], {'max_length': '100', 'null': 'True', 'blank': 'True'}),
+            u'id': ('django.db.models.fields.AutoField', [], {'primary_key': 'True'}),
+            'journal': ('django.db.models.fields.CharField', [], {'max_length': '500', 'blank': 'True'}),
+            'lecture_notes_archive_file': ('django.db.models.fields.files.FileField', [], {'max_length': '100', 'null': 'True', 'blank': 'True'}),
+            'legacy_id': ('django.db.models.fields.IntegerField', [], {'null': 'True', 'blank': 'True'}),
+            'manual_citation': ('markitup.fields.MarkupField', [], {'max_length': '500', 'no_rendered_field': 'True', 'blank': 'True'}),
+            'modified': ('model_utils.fields.AutoLastModifiedField', [], {'default': 'datetime.datetime.now'}),
+            'month': ('django.db.models.fields.CharField', [], {'max_length': '500', 'blank': 'True'}),
+            'notes_for_staff': ('django.db.models.fields.TextField', [], {'max_length': '5000', 'blank': 'True'}),
+            'number': ('django.db.models.fields.CharField', [], {'max_length': '500', 'blank': 'True'}),
+            'pages': ('django.db.models.fields.CharField', [], {'max_length': '500', 'blank': 'True'}),
+            'paper_abstract': ('markitup.fields.MarkupField', [], {'max_length': '5000', 'no_rendered_field': 'True', 'blank': 'True'}),
+            'primary_research_field': ('django.db.models.fields.CharField', [], {'max_length': '300', 'blank': 'True'}),
+            'related_urls': ('jsonfield.fields.JSONField', [], {'default': "'{}'"}),
+            'secondary_research_field': ('django.db.models.fields.CharField', [], {'max_length': '300', 'blank': 'True'}),
+            'site_owner': ('django.db.models.fields.related.ForeignKey', [], {'to': u"orm['users.User']"}),
+            'solution_archive_file': ('django.db.models.fields.files.FileField', [], {'max_length': '100', 'null': 'True', 'blank': 'True'}),
+            'status': ('model_utils.fields.StatusField', [], {'default': "'draft'", 'max_length': '100', u'no_check_for_status': 'True'}),
+            'status_changed': ('model_utils.fields.MonitorField', [], {'default': 'datetime.datetime.now', u'monitor': "u'status'"}),
+            'title': ('django.db.models.fields.CharField', [], {'max_length': '500'}),
+            'verification_archive_file': ('django.db.models.fields.files.FileField', [], {'max_length': '100', 'null': 'True', 'blank': 'True'}),
+            'volume': ('django.db.models.fields.CharField', [], {'max_length': '500', 'blank': 'True'}),
+            'year': ('django.db.models.fields.CharField', [], {'max_length': '500', 'blank': 'True'})
+        },
+        u'compendia.contributor': {
+            'Meta': {'ordering': "['citation_order', 'user']", 'object_name': 'Contributor'},
+            'article': ('django.db.models.fields.related.ForeignKey', [], {'to': u"orm['compendia.Article']"}),
+            'citation_order': ('django.db.models.fields.IntegerField', [], {'null': 'True', 'blank': 'True'}),
+            'created': ('model_utils.fields.AutoCreatedField', [], {'default': 'datetime.datetime.now'}),
+            u'id': ('django.db.models.fields.AutoField', [], {'primary_key': 'True'}),
+            'modified': ('model_utils.fields.AutoLastModifiedField', [], {'default': 'datetime.datetime.now'}),
+            'role': ('django.db.models.fields.CharField', [], {'max_length': '50', 'blank': 'True'}),
+            'user': ('django.db.models.fields.related.ForeignKey', [], {'to': u"orm['users.User']"})
+        },
+        u'compendia.tableofcontentsoption': {
+            'Meta': {'object_name': 'TableOfContentsOption'},
+            '_description_rendered': ('django.db.models.fields.TextField', [], {'blank': 'True'}),
+            'compendium_type': ('django.db.models.fields.CharField', [], {'default': "'misc'", 'unique': 'True', 'max_length': '100'}),
+            'description': ('markitup.fields.MarkupField', [], {'max_length': '500', 'no_rendered_field': 'True', 'blank': 'True'}),
+            u'id': ('django.db.models.fields.AutoField', [], {'primary_key': 'True'})
+        },
+        u'compendia.taggedarticle': {
+            'Meta': {'object_name': 'TaggedArticle'},
+            'content_object': ('django.db.models.fields.related.ForeignKey', [], {'to': u"orm['compendia.Article']"}),
+            u'id': ('django.db.models.fields.AutoField', [], {'primary_key': 'True'}),
+            'tag': ('django.db.models.fields.related.ForeignKey', [], {'related_name': "u'compendia_taggedarticle_items'", 'to': u"orm['taggit.Tag']"}),
+            'tag_type': ('django.db.models.fields.CharField', [], {'default': "'folksonomic'", 'max_length': '50', 'blank': 'True'})
+        },
+        u'compendia.verification': {
+            'Meta': {'ordering': "['-created']", 'object_name': 'Verification'},
+            'archive_file': ('django.db.models.fields.files.FileField', [], {'max_length': '100', 'blank': 'True'}),
+            'archive_info': ('jsonfield.fields.JSONField', [], {'default': "'{}'"}),
+            'article': ('django.db.models.fields.related.ForeignKey', [], {'to': u"orm['compendia.Article']"}),
+            'created': ('model_utils.fields.AutoCreatedField', [], {'default': 'datetime.datetime.now'}),
+            u'id': ('django.db.models.fields.AutoField', [], {'primary_key': 'True'}),
+            'modified': ('model_utils.fields.AutoLastModifiedField', [], {'default': 'datetime.datetime.now'}),
+            'parameters': ('jsonfield.fields.JSONField', [], {'default': "'{}'"}),
+            'requestid': ('django.db.models.fields.CharField', [], {'max_length': '50', 'blank': 'True'}),
+            'slug': ('autoslug.fields.AutoSlugField', [], {'unique_with': "('article',)", 'max_length': '50', 'populate_from': "'populate_slug'"}),
+            'status': ('model_utils.fields.StatusField', [], {'default': "'unknown'", 'max_length': '100', u'no_check_for_status': 'True'}),
+            'status_changed': ('model_utils.fields.MonitorField', [], {'default': 'datetime.datetime.now', u'monitor': "u'status'"}),
+            'stderr': ('django.db.models.fields.TextField', [], {'blank': 'True'}),
+            'stdout': ('django.db.models.fields.TextField', [], {'blank': 'True'})
+        },
+        u'contenttypes.contenttype': {
+            'Meta': {'ordering': "('name',)", 'unique_together': "(('app_label', 'model'),)", 'object_name': 'ContentType', 'db_table': "'django_content_type'"},
+            'app_label': ('django.db.models.fields.CharField', [], {'max_length': '100'}),
+            u'id': ('django.db.models.fields.AutoField', [], {'primary_key': 'True'}),
+            'model': ('django.db.models.fields.CharField', [], {'max_length': '100'}),
+            'name': ('django.db.models.fields.CharField', [], {'max_length': '100'})
+        },
+        u'taggit.tag': {
+            'Meta': {'object_name': 'Tag'},
+            u'id': ('django.db.models.fields.AutoField', [], {'primary_key': 'True'}),
+            'name': ('django.db.models.fields.CharField', [], {'unique': 'True', 'max_length': '100'}),
+            'slug': ('django.db.models.fields.SlugField', [], {'unique': 'True', 'max_length': '100'})
+        },
+        u'users.user': {
+            'Meta': {'object_name': 'User'},
+            'affiliation': ('django.db.models.fields.CharField', [], {'max_length': '200', 'blank': 'True'}),
+            'biography': ('django.db.models.fields.TextField', [], {'max_length': '400', 'blank': 'True'}),
+            'country': ('django.db.models.fields.CharField', [], {'max_length': '200', 'blank': 'True'}),
+            'date_joined': ('django.db.models.fields.DateTimeField', [], {'default': 'datetime.datetime.now'}),
+            'email': ('django.db.models.fields.EmailField', [], {'max_length': '75', 'blank': 'True'}),
+            'first_name': ('django.db.models.fields.CharField', [], {'max_length': '30', 'blank': 'True'}),
+            'groups': ('django.db.models.fields.related.ManyToManyField', [], {'symmetrical': 'False', 'related_name': "u'user_set'", 'blank': 'True', 'to': u"orm['auth.Group']"}),
+            u'id': ('django.db.models.fields.AutoField', [], {'primary_key': 'True'}),
+            'is_active': ('django.db.models.fields.BooleanField', [], {'default': 'True'}),
+            'is_staff': ('django.db.models.fields.BooleanField', [], {'default': 'False'}),
+            'is_superuser': ('django.db.models.fields.BooleanField', [], {'default': 'False'}),
+            'last_login': ('django.db.models.fields.DateTimeField', [], {'default': 'datetime.datetime.now'}),
+            'last_name': ('django.db.models.fields.CharField', [], {'max_length': '30', 'blank': 'True'}),
+            'password': ('django.db.models.fields.CharField', [], {'max_length': '128'}),
+            'public_name': ('django.db.models.fields.CharField', [], {'max_length': '150', 'blank': 'True'}),
+            'urls': ('json_field.fields.JSONField', [], {'default': "'{}'"}),
+            'user_permissions': ('django.db.models.fields.related.ManyToManyField', [], {'symmetrical': 'False', 'related_name': "u'user_set'", 'blank': 'True', 'to': u"orm['auth.Permission']"}),
+            'username': ('django.db.models.fields.CharField', [], {'unique': 'True', 'max_length': '30'})
+        }
+    }
+
+    complete_apps = ['compendia']

--- a/companionpages/compendia/models.py
+++ b/companionpages/compendia/models.py
@@ -184,3 +184,17 @@ class Verification(StatusModel, TimeStampedModel):
         ordering = ['-created']
         verbose_name = _(u'verification')
         verbose_name_plural = _(u'verifications')
+
+
+class TableOfContentsOption(models.Model):
+    compendium_type = models.CharField(max_length=100, choices=choices.ENTRY_TYPES, default='misc', unique=True)
+    description = MarkupField(max_length=500, blank=True, verbose_name=_(u'Description'),
+        help_text=_(u'Write an optional descrption to appear with the Table of Contents entry.'
+                    u'Markdown is allowed. (500 characters maximum)'))
+
+    def __unicode__(self):
+        return self.compendium_type
+
+    class Meta(object):
+        verbose_name = _(u'Table of Contents Option')
+        verbose_name_plural = _(u'Table of Contents Options')

--- a/companionpages/compendia/urls.py
+++ b/companionpages/compendia/urls.py
@@ -7,6 +7,7 @@ urlpatterns = patterns(
     url(r'^$', views.ArticleListView.as_view(), name='list'),
     url(r'^browse/(?P<compendium_type>.*)/$', views.ArticleTypeListView.as_view(), name='browse'),
     url(r'^b/$', views.ArticleBrowseView.as_view(), name='b'),
+    url(r'^toc/$', views.TableOfContentsView.as_view(), name='toc'),
     url(r'^create/$', views.ArticleCreateView.as_view(), name='create'),
     url(r'^(?P<year>\d{4})\.(?P<pk>\d+)/$', views.ArticleYearView.as_view(), name='year_detail'),
     url(r'^(?P<pk>\d+)/$', views.ArticleDetailView.as_view(), name='pk_detail'),

--- a/companionpages/compendia/views.py
+++ b/companionpages/compendia/views.py
@@ -10,7 +10,7 @@ from braces.views import FormMessagesMixin, LoginRequiredMixin
 from haystack.query import SearchQuerySet
 from haystack.views import FacetedSearchView
 
-from .models import Article
+from .models import Article, TableOfContentsOption
 from .forms import ArticleForm, ArticleUpdateForm
 from . import choices
 
@@ -26,6 +26,10 @@ class ArticleFacetedSearchView(FacetedSearchView):
         extra['compendium_type_lookup'] = choices.ENTRY_TYPE_LOOKUP
         extra['research_field_lookup'] = choices.RESEARCH_FIELD_LOOKUP
         return extra
+
+class TableOfContentsView(generic.ListView):
+    model = TableOfContentsOption
+    template_name = 'asa.html'
 
 
 class ArticleBrowseView(generic.base.TemplateView):
@@ -86,6 +90,7 @@ class ArticleListView(generic.ListView):
 
 
 class ArticleTypeListView(ArticleListView):
+    template_name = 'compendia/title_list.html'
 
     def get_queryset(self):
         compendium_type = self.kwargs.get('compendium_type', None)

--- a/companionpages/compendia/views.py
+++ b/companionpages/compendia/views.py
@@ -27,6 +27,7 @@ class ArticleFacetedSearchView(FacetedSearchView):
         extra['research_field_lookup'] = choices.RESEARCH_FIELD_LOOKUP
         return extra
 
+
 class TableOfContentsView(generic.ListView):
     model = TableOfContentsOption
     template_name = 'asa.html'

--- a/companionpages/templates/asa.html
+++ b/companionpages/templates/asa.html
@@ -1,0 +1,23 @@
+{% extends "base.html" %}
+{% load home_tags %}
+{% load flatblock_tags %}
+
+{% block title %}ASA Commons{% endblock %}
+
+{% block content %}
+
+<div class="row">
+
+{% flatblock "asa.info" %}
+
+<ul>
+{% for option in object_list %}
+<li>
+<a href="{% url 'compendia:browse' option.compendium_type|urlencode %}">{{ option.get_compendium_type_display }}</a>
+</li>
+{% endfor %}
+</ul>
+
+
+</div> <!-- row -->
+{% endblock content %}

--- a/companionpages/templates/compendia/card_browse.html
+++ b/companionpages/templates/compendia/card_browse.html
@@ -7,10 +7,6 @@
   <div class="panel-body">
     <p>{{ compendium.journal }}</p>
     <p>{{ compendium.authors_text|truncatewords_html:100 }}</p>
-    {% autoescape off %}
-    <p>{{ compendium.code_data_abstract|truncatewords_html:100 }}</p>
-    {% endautoescape %}
-
     <p><a class="btn btn-primary" href="{% url 'compendia:pk_detail' compendium.pk %}"><i class="fa fa-book"></i> Details</a></p>
   </div>
 </div>

--- a/companionpages/templates/compendia/card_title.html
+++ b/companionpages/templates/compendia/card_title.html
@@ -1,0 +1,17 @@
+<div class="panel panel-default">
+  <div class="panel-heading">
+    <a href="{{ obj.get_absolute_url }}">
+        {{ obj.title }}
+    </a>
+  </div>
+
+  <div class="panel-body">
+    <p>{{ obj.journal }}</p>
+    <p>{{ obj.authors_text|truncatewords:100 }}</p>
+    {% if obj.get_absolute_url %}
+      <a class="btn btn-primary" href="{{ obj.get_absolute_url }}"><i class="fa fa-book"></i> Details</a>
+    {% elif obj.pk %}
+      <a class="btn btn-primary" href="{% url 'compendia:pk_detail' compendium.pk %}"><i class="fa fa-book"></i> Details</a></br>
+    {% endif %}
+  </div>
+</div>

--- a/companionpages/templates/compendia/index.html
+++ b/companionpages/templates/compendia/index.html
@@ -9,62 +9,13 @@
 {% include "compendia/facets_browse.html" %}
 </p>
 
-{{ page_obj.start_index }} through {{ page_obj.end_index }} of {{ paginator.count }} results
-
-<div class="container">
-{% if page_obj.has_other_pages %}
-<ul class="pagination" style="float:right">
-
-{% if page_obj.has_previous %}
-<li><a href="?page={{ page_obj.previous_page_number }}">&laquo</a></li>
-{% else %}
-<li class="disabled"><a href="#">&laquo</a></li>
-{% endif %}
-
-{% for num in paginator.page_range %}
-<li class="{% if page_obj.number == num %}active{% endif %}">
-  <a href="?page={{num}}">{{ num }}</a>
-</li>
-{% endfor %}
-
-{% if page_obj.has_next %}
-<li><a href="?page={{ page_obj.next_page_number }}">&raquo</a></li>
-{% else %}
-<li class="disabled"><a href="#">&raquo</a></li>
-{% endif %}
-</ul>
-
-{% endif %}
-</div>
+{% include "compendia/pagination.html" %}
 
 {% for obj in object_list %}
 {% include "compendia/card_index.html" %}
 {% endfor %}
 
-{{ page_obj.start_index }} through {{ page_obj.end_index }} of {{ paginator.count }} results
-
-{% if page_obj.has_other_pages %}
-<ul class="pagination" style="float:right">
-
-{% if page_obj.has_previous %}
-<li><a href="?page={{ page_obj.previous_page_number }}">&laquo</a></li>
-{% else %}
-<li class="disabled"><a href="#">&laquo</a></li>
-{% endif %}
-
-{% for num in paginator.page_range %}
-<li class="{% if page_obj.number == num %}active{% endif %}">
-  <a href="?page={{num}}">{{ num }}</a>
-</li>
-{% endfor %}
-
-{% if page_obj.has_next %}
-<li><a href="?page={{ page_obj.next_page_number }}">&raquo</a></li>
-{% else %}
-<li class="disabled"><a href="#">&raquo</a></li>
-{% endif %}
-</ul>
-{% endif %}
+{% include "compendia/pagination.html" %}
 
 {% endif %}
 

--- a/companionpages/templates/compendia/pagination.html
+++ b/companionpages/templates/compendia/pagination.html
@@ -1,0 +1,32 @@
+{{ page_obj.start_index }} through {{ page_obj.end_index }} of {{ paginator.count }} results
+
+<div class="container">
+
+{% if page_obj.has_other_pages %}
+
+  <ul class="pagination" style="float:right">
+
+  {% if page_obj.has_previous %}
+    <li><a href="?page={{ page_obj.previous_page_number }}">&laquo</a></li>
+  {% else %}
+    <li class="disabled"><a href="#">&laquo</a></li>
+  {% endif %}
+
+  {% for num in paginator.page_range %}
+    <li class="{% if page_obj.number == num %}active{% endif %}">
+      <a href="?page={{num}}">{{ num }}</a>
+    </li>
+  {% endfor %}
+
+  {% if page_obj.has_next %}
+    <li><a href="?page={{ page_obj.next_page_number }}">&raquo</a></li>
+  {% else %}
+    <li class="disabled"><a href="#">&raquo</a></li>
+  {% endif %}
+
+</ul>
+
+{% endif %}
+</div>
+
+

--- a/companionpages/templates/compendia/title_list.html
+++ b/companionpages/templates/compendia/title_list.html
@@ -1,0 +1,31 @@
+{% extends 'base.html' %}
+{% load tz %}
+
+{% block content %}
+
+{% if object_list %}
+
+{% include "compendia/pagination.html" %}
+
+<ul>
+{% for obj in object_list %}
+  <li>
+    <a href="{{ obj.get_absolute_url }}">{{ obj.title }}</a>
+    {% include "compendia/citation.html" with article=obj %}
+  </li>
+{% endfor %}
+</ul>
+
+{% include "compendia/pagination.html" %}
+
+{% else %}
+
+<p>No Research Compendia of this type. Create one.</p>
+
+  <form action="{% url 'compendia:create' %}" method="get">
+    <button type='submit' class='btn btn-primary'>Create Research Compendium</button>
+  </form>
+
+{% endif %}
+
+{% endblock content %}


### PR DESCRIPTION
This adds a sample Table of Contents view for the ASA Commons with the a list of results based on the request from the ASA group. Results cards for this type of browsing won't have abstract information. With new browsing types of pages the pagination logic was getting repeated a lot so it has been factored out in to a separate template for DRY and also so that we have consistent pagination style.
