### PR TITLE
add multiselects to search for type and research

### DIFF
--- a/companionpages/compendia/views.py
+++ b/companionpages/compendia/views.py
@@ -11,15 +11,17 @@ from haystack.query import SearchQuerySet
 from haystack.views import FacetedSearchView
 
 from .models import Article, TableOfContentsEntry
-from .forms import ArticleForm, ArticleUpdateForm
+from .forms import ArticleForm, ArticleUpdateForm, ArticleFacetedSearchForm
 from . import choices
 
 logger = logging.getLogger('researchcompendia.compendia')
 
 
 class ArticleFacetedSearchView(FacetedSearchView):
+
     def __init__(self, *args, **kwargs):
         super(ArticleFacetedSearchView, self).__init__(*args, **kwargs)
+        self.form_class = ArticleFacetedSearchForm
 
     def extra_context(self):
         extra = super(ArticleFacetedSearchView, self).extra_context()

--- a/companionpages/templates/asa.html
+++ b/companionpages/templates/asa.html
@@ -19,5 +19,4 @@
   {% endfor %}
   </ul>
 </div>
-
 {% endblock content %}

--- a/companionpages/templates/base.html
+++ b/companionpages/templates/base.html
@@ -24,7 +24,10 @@
       var s = document.getElementsByTagName('script')[0]; s.parentNode.insertBefore(ga, s);
     })();
 
-</script>
+  </script>
+
+  {% block extra_header %}
+  {% endblock extra_header %}
   <!-- Le styles -->
 
   <!--

--- a/companionpages/templates/compendia/facets.html
+++ b/companionpages/templates/compendia/facets.html
@@ -10,6 +10,6 @@ compendia types:
 {% if facets.fields.primary_research_field %}
 research fields:
 {% for field, count in facets.fields.primary_research_field|slice:":5" %}
-<a href="{{ request.get_full_path }}&amp;selected_facets=primary_research_field:{{ field|urlencode }}">{{ research_field_lookup|lookup:field }}</a>({{ count }})</li>
+<a href="{{ request.get_full_path }}&amp;selected_facets=primary_research_field_exact:{{ field|urlencode }}">{{ research_field_lookup|lookup:field }}</a>({{ count }})</li>
 {% endfor %}
 {% endif %}

--- a/companionpages/templates/search/indexes/compendia/article_text.txt
+++ b/companionpages/templates/search/indexes/compendia/article_text.txt
@@ -1,3 +1,8 @@
-{{ object.authors_text }}
+{{ object.journal }}
 {{ object.title }}
+{{ object.authors_text }}
 {{ object.code_data_abstract }}
+{{ object.paper_abstract }}
+{{ object.doi }}
+{{ object.code_doi }}
+{{ object.data_doi }}

--- a/companionpages/templates/search/search.html
+++ b/companionpages/templates/search/search.html
@@ -6,11 +6,10 @@
 {% block content %}
 
 <form method="get" action=".">
+
   {{ form|crispy }}
 
 {% if query %}
-
-  {% include "compendia/facets.html" %}
 
   <h3>Results</h3>
 
@@ -59,4 +58,4 @@
 
 </form>
 
-{% endblock content %}
+{% endblock %}


### PR DESCRIPTION
- Compendium type and primary research field can be multiselected during a
  search. The search results will be filtered through an OR across the
  selected values.
- We are now searching over journal title and DOIs.
